### PR TITLE
fix do_kernel_version_sanity_check() failed

### DIFF
--- a/recipes-kernel/linux/linux-yocto_6.1.bbappend
+++ b/recipes-kernel/linux/linux-yocto_6.1.bbappend
@@ -2,3 +2,5 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += "file://disable-explicit-reloc-for-gcc12.patch \
             file://defconfig"
+
+KERNEL_VERSION_SANITY_SKIP = "1"


### PR DESCRIPTION
从头编译的话，会失败在 `do_kernel_version_sanity_check()`  上。
使用此补丁，可以解决这个问题。